### PR TITLE
Fix React Query options

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -32,11 +32,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     refetch
   } = useQuery<User | null>({
     queryKey: ["/api/user"],
-    queryFn: getQueryFn({ on401: "returnNull" }),
+    queryFn: getQueryFn<User | null>({ on401: "returnNull" }),
     retry: 1,
     retryDelay: 1000,
     staleTime: Infinity,
-    cacheTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true
   });

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -27,7 +27,7 @@ export async function apiRequest(
     await throwIfResNotOk(res);
     return res;
   } catch (error) {
-    if (error.name === 'AbortError') {
+    if (error instanceof Error && error.name === 'AbortError') {
       throw new Error('Request timed out');
     }
     throw error;


### PR DESCRIPTION
## Summary
- correct React Query configuration for v5
- guard against unknown error types in `apiRequest`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684b7be4853c832e9a5158853bf26409