### PR TITLE
Ensure openai lib loads env variables

### DIFF
--- a/server/lib/openai.ts
+++ b/server/lib/openai.ts
@@ -1,5 +1,9 @@
 import OpenAI from "openai";
 import { type ChatSettings } from "@shared/schema";
+import dotenv from "dotenv";
+
+// Ensure environment variables are loaded when this module is imported.
+dotenv.config();
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 


### PR DESCRIPTION
## Summary
- load environment variables inside `server/lib/openai.ts`
- run `npm run dev` to confirm the app starts

## Testing
- `npm run check`
- `npm run dev` *(fails without OPENAI_API_KEY, but succeeds with dummy env)*

------
https://chatgpt.com/codex/tasks/task_e_684c967727f4832eadb853e4505969eb