### PR TITLE
Add Postgres docker setup and DB storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ LingoBot is an AI-powered chat application with secure authentication and custom
    npm run dev
    ```
 
+### Local Database with Docker
+
+If you don't have a PostgreSQL server available, you can start one using Docker:
+
+```bash
+docker-compose up -d
+```
+
+This will launch a database listening on `localhost:5432` with credentials
+`lingobot`/`lingobot`. Update your `.env` with:
+
+```bash
+DATABASE_URL=postgresql://lingobot:lingobot@localhost:5432/lingobot
+```
+
+After the database is running, initialize the schema:
+
+```bash
+npm run db:push
+```
+
 ## Running the Standalone Executable
 1. Download the appropriate executable for your platform:
    - `ai-chat-assistant-win.exe`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: lingobot
+      POSTGRES_PASSWORD: lingobot
+      POSTGRES_DB: lingobot
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:
+

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,15 +1,12 @@
-import { Pool, neonConfig } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-serverless';
-import ws from "ws";
+import pgPkg from 'pg';
+const { Pool } = pgPkg;
+import { drizzle } from 'drizzle-orm/node-postgres';
 import * as schema from "@shared/schema";
 
-neonConfig.webSocketConstructor = ws;
+export let pool: pgPkg.Pool | undefined;
+export let db: ReturnType<typeof drizzle> | undefined;
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
+if (process.env.DATABASE_URL) {
+  pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  db = drizzle(pool, { schema });
 }
-
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-export const db = drizzle({ client: pool, schema });


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with a Postgres service
- document how to run the DB locally in README
- update `db.ts` to allow optional DB connection
- implement `PgStorage` and switch automatically when `DATABASE_URL` is set

## Testing
- `npm install`
- `npm run check`
- `npm run build`
- `OPENAI_API_KEY=dummy SESSION_SECRET=secret npm run dev` *(fails without docker DB but starts with MemStorage)*
- `docker-compose up -d` *(failed: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684dcd663e7c832eb148dacdf1b66224